### PR TITLE
Adding command to exterminage naughty ros/gazebo processes that got stuck.

### DIFF
--- a/miscellaneous/shell_additions/shell_additions.sh
+++ b/miscellaneous/shell_additions/shell_additions.sh
@@ -781,3 +781,15 @@ appendBag() {
 }
 
 # #}
+
+# #{ rosRemnantCleanup()
+
+rosRemnantCleanup() {
+
+  for keyword in {nodelet,ros,gz,gazebo}
+  do
+    sudo pkill -f $keyword
+  done
+}
+
+# #}

--- a/miscellaneous/shell_additions/shell_additions.sh
+++ b/miscellaneous/shell_additions/shell_additions.sh
@@ -786,7 +786,7 @@ appendBag() {
 
 rosRemnantCleanup() {
 
-  for keyword in {nodelet,ros,gz,gazebo}
+  for keyword in {nodelet,ros,gz,gazebo,px4}
   do
     sudo pkill -f $keyword
   done


### PR DESCRIPTION
Sometimes, a simulation session leaves some nodes or other executables running. This takes care of that.
Suggestion: call this within the session kill command.