### PR TITLE
updated mrs_rviz_plugins, mrs_uav_managers, and mrs_uav_odometry

### DIFF
--- a/.gitman.yml
+++ b/.gitman.yml
@@ -303,7 +303,7 @@ sources_locked:
       - git submodule update --init --recursive
   - repo: https://github.com/ctu-mrs/mrs_rviz_plugins.git
     name: mrs_rviz_plugins
-    rev: 571bf999c9aa0f78c954171e3374149527202de8
+    rev: cd24b9b1ea25a78530518752735db9ab49dd5ce7
     type: git
     params:
     sparse_paths:
@@ -339,7 +339,7 @@ sources_locked:
       - git submodule update --init --recursive
   - repo: https://github.com/ctu-mrs/mrs_uav_managers.git
     name: mrs_uav_managers
-    rev: dcd53b091812bd800efb1e3fce506b2876371841
+    rev: a1b90580ecfdd343bae87ec2a4c07cce609242f4
     type: git
     params:
     sparse_paths:
@@ -351,7 +351,7 @@ sources_locked:
       - git submodule update --init --recursive
   - repo: https://github.com/ctu-mrs/mrs_uav_odometry.git
     name: mrs_uav_odometry
-    rev: 04dea2e858946e4292d5236081c26fb13b31babb
+    rev: c0d6a5d6982fc238ccec00a153d216cea158bb0f
     type: git
     params:
     sparse_paths:


### PR DESCRIPTION
updated:
- mrs_rviz_plugins - rewritten rviz_nav_goal, `reference_service_name` and `rviz_topic_name` can now be set from launch file arguments
- mrs_uav_managers - updated gains for f330
- mrs_uav_odometry - using repredictor for VIO estimator and commit https://github.com/ctu-mrs/mrs_uav_odometry/commit/c0d6a5d6982fc238ccec00a153d216cea158bb0f